### PR TITLE
Remove Resize Borders around Seamless windows

### DIFF
--- a/ServerExe/Makefile.am
+++ b/ServerExe/Makefile.am
@@ -32,12 +32,12 @@ if OS_IS_WIN32
 lib_LTLIBRARIES = seamlessrdp32.la
 seamlessrdp32_la_SOURCES = hookdll.c
 seamlessrdp32_la_LDFLAGS = -avoid-version -module -no-undefined 
-seamlessrdp32_la_LIBADD = libshared.la libvchannel.la -lgdi32
+seamlessrdp32_la_LIBADD = libshared.la libvchannel.la -lgdi32 -ldwmapi
 endif
 
 if OS_IS_WIN64
 lib_LTLIBRARIES = seamlessrdp64.la
 seamlessrdp64_la_SOURCES = hookdll.c
 seamlessrdp64_la_LDFLAGS = -avoid-version -module -no-undefined 
-seamlessrdp64_la_LIBADD = libshared.la libvchannel.la -lgdi32
+seamlessrdp64_la_LIBADD = libshared.la libvchannel.la -lgdi32 -ldwmapi
 endif


### PR DESCRIPTION
Offset the window coordinates with the width of the border. This
avoids having thick borders with the surrounding desktop contents
shining through into the Seamless window.

This requires dwmapi which was introduced in Windows Vista/Windows
Server 2008.